### PR TITLE
implement standalone functionality of FoamDictParser

### DIFF
--- a/src/Owls/parser/FoamDict.py
+++ b/src/Owls/parser/FoamDict.py
@@ -87,7 +87,7 @@ class OFInclude:
         """Convert a python list to a str with OF syntax"""
         key = args[0].split("_")[0]
         value = args[1]
-        return f'{kwargs.get("indent", "")}{key} {value}{kwargs.get("nl",os.linesep)}'
+        return f'{kwargs.get("indent", "")}{key} "{value}"{kwargs.get("nl",os.linesep)}'
 
 
 class OFDimensionSet:
@@ -249,9 +249,11 @@ class FileParser:
         with open(fn, "r") as fh:
             return fh.readlines()
 
-    def write_to_disk(self):
+    def write_to_disk(self, path=None):
         """writes a parsed OF file back into a file"""
         fn = self.path
+        if path is not None:
+            fn = path
         dictionary = self._dict
 
         with open(fn, "w") as fh:

--- a/src/Owls/parser/FoamDict.py
+++ b/src/Owls/parser/FoamDict.py
@@ -40,10 +40,10 @@ class OFList:
         return (
             pp.Word(pp.alphanums)
             + pp.Suppress("(")
-            + pp.OneOrMore(pp.Word(pp.alphanums + '_-."/'), stopOn=pp.Literal(")"))
+            + pp.OneOrMore(pp.Word(pp.alphanums + '_-."/'), stop_on=pp.Literal(")"))
             + pp.Suppress(")")
             + pp.Suppress(";")
-        ).setResultsName("of_list")
+        ).set_results_name("of_list")
 
     def to_str(self, *args, **kwargs):
         """Convert a python list to a str with OF syntax"""
@@ -61,7 +61,7 @@ class OFVariable:
         # TODO make it recursive
         return (
             pp.Literal("$") + pp.Word(pp.alphanums) + pp.Suppress(";")
-        ).setResultsName("of_variable")
+        ).set_results_name("of_variable")
 
     def to_str(self, *args, **kwargs):
         """Convert a python list to a str with OF syntax"""
@@ -101,7 +101,7 @@ class OFDimensionSet:
             + pp.Suppress("]")
             + pp.Word(pp.alphanums + '_-."/')
             + pp.Suppress(";")
-        ).setResultsName("of_dimension_set")
+        ).set_results_name("of_dimension_set")
 
     def to_str(self):
         pass
@@ -143,7 +143,7 @@ class FileParser:
                 ^ OFVariable.parse()
                 ^ OFDimensionSet.parse()
                 ^ (
-                    pp.Word(pp.alphanums + '"#(),|*').setResultsName("key")
+                    pp.Word(pp.alphanums + '"#(),|*').set_results_name("key")
                     + (
                         pp.OneOrMore(pp.Word(pp.alphanums + '".-')) + pp.Suppress(";")
                         # all kinds of values delimeted by ;
@@ -151,15 +151,15 @@ class FileParser:
                         ^ pp.Word(
                             pp.alphanums + '"_.-/'
                         )  # for includes which are single strings can contain /
-                    ).setResultsName("value")
+                    ).set_results_name("value")
                 )
             )
             .ignore(pp.cStyleComment | pp.dblSlashComment)
-            .setResultsName("key_value_pair")
+            .set_results_name("key_value_pair")
         )
         of_dict <<= (
             pp.Suppress("{") + pp.ZeroOrMore(key_val_pair) + pp.Suppress("}")
-        ).setResultsName("of_dict")
+        ).set_results_name("of_dict")
         return key_val_pair
 
     @property
@@ -167,7 +167,7 @@ class FileParser:
         """matches a b; or a (a b c);"""
         return pp.Group(
             pp.Literal("//") + pp.ZeroOrMore(pp.Word(pp.alphanums + '#_-."/'))
-        ).setResultsName("single_line_comment")
+        ).set_results_name("single_line_comment")
 
     @property
     def config_parser(self):

--- a/src/Owls/parser/FoamDict.py
+++ b/src/Owls/parser/FoamDict.py
@@ -124,11 +124,8 @@ class FileParser:
     def separator(self):
         return "// " + "* " * 26 + "//"
 
-    def get(self, key):
-        try:
-            return self._dict[key]
-        except KeyError as e:
-            print(e)
+    def get(self, key, default=None):
+        return self._dict.get(key, default)
 
     @property
     def key_value_pair(self):
@@ -175,7 +172,7 @@ class FileParser:
             pp.ZeroOrMore(self.single_line_comment) ^ pp.ZeroOrMore(self.key_value_pair)
         )
 
-    def convert_to_number(self, inp):
+    def convert_to_number(self, inp: list[str]):
         """converts to number if possible, return str otherwise"""
         s = " ".join(inp)
         try:
@@ -189,7 +186,7 @@ class FileParser:
         for res in parse_result:
             # probe if next result is str or ParseResult
             if isinstance(res, pp.ParseResults):
-                if res.getName() == "key_value_pair":
+                if res.get_name() == "key_value_pair":
                     key = res.key
                     # keys starting with # need special attention to avoid overwriting
                     # them in the return dictionary
@@ -205,7 +202,7 @@ class FileParser:
                         d = {key: self.key_value_to_dict([v for v in res.value])}
                         ret.update(d)
                     elif res.get("of_list"):
-                        tmp_list = res.get("of_list").asList()
+                        tmp_list = res.get("of_list").as_list()
                         key = tmp_list[0]
                         values = list(
                             map(
@@ -239,7 +236,7 @@ class FileParser:
 
     def parse_str_to_dict(self, s) -> dict:
         """Parse a given FoamDict body str to a python dictionary"""
-        self.parse = self.config_parser.searchString(s)
+        self.parse = self.config_parser.search_string(s)
         # if len(self.parse) is bigger than one the parse function
         # did not consume the file entirely and something went most likely wrong
         return self.key_value_to_dict(self.parse[0][0])

--- a/tests/test_standalone_parser.py
+++ b/tests/test_standalone_parser.py
@@ -1,0 +1,84 @@
+import os
+
+import Owls.parser.FoamDict as fd
+
+import pytest
+
+
+exec_path = os.getcwd()
+
+control_dict = r'''/*--------------------------------*- C++ -*----------------------------------*\
+  =========                 |
+  \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
+   \\    /   O peration     | Website:  https://openfoam.org
+    \\  /    A nd           | Version:  10
+     \\/     M anipulation  |
+\*---------------------------------------------------------------------------*/
+FoamFile
+{
+    format      ascii;
+    class       dictionary;
+    location    "system";
+    object      controlDict;
+}
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+application     simpleFoam;
+
+startFrom       startTime;
+
+startTime       0;
+
+stopAt          endTime;
+
+endTime         500;
+
+deltaT          1;
+
+writeControl    timeStep;
+
+writeInterval   50;
+
+purgeWrite      0;
+
+writeFormat     ascii;
+
+writePrecision  6;
+
+writeCompression off;
+
+timeFormat      general;
+
+timePrecision   6;
+
+runTimeModifiable true;
+
+
+// ************************************************************************* //
+'''
+
+
+@pytest.fixture
+def setup_tmp_cDict(tmp_path):
+    f1 = tmp_path / "tmpControlDicts/controldict"
+    f1.parent.mkdir()
+    f1.touch
+    f1.write_text(control_dict)
+    return f1
+
+
+def test_setup_parser(setup_tmp_cDict):
+    parser = fd.FileParser(path=setup_tmp_cDict)
+    assert isinstance(parser, fd.FileParser)
+
+
+def test_parser_get(setup_tmp_cDict):
+    parser = fd.FileParser(path=setup_tmp_cDict)
+
+    w_prec = parser.get('writePrecision')  # should return 6
+    t_prec = parser.get('timePrecision')   # should return 6
+    e_time = parser.get('endTime')         # should return 500 
+
+    assert w_prec == 6
+    assert t_prec == 6
+    assert e_time == 500


### PR DESCRIPTION
also, fixes some pyparsing naming errors, e.g., chenging `set_results_name` to `setResultsName`.
fixes #21 